### PR TITLE
Remove index route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 RailsgirlsLondon::Application.routes.draw do
   devise_for :users, skip: :registrations
 
-  get "home/index"
-
   namespace :admin do
     resources :cities, only: [:new, :create, :index]
     resources :events


### PR DESCRIPTION
As the home/index route is covered by the default route, is there any need for this? If other pages need the homepage they can simply link to root_path or root_url.
