### PR TITLE
Add database config via environment variables

### DIFF
--- a/config/initializers/database_connection.rb
+++ b/config/initializers/database_connection.rb
@@ -1,0 +1,10 @@
+Rails.application.config.after_initialize do
+  ActiveRecord::Base.connection_pool.disconnect!
+
+  ActiveSupport.on_load(:active_record) do
+    config = Rails.application.config.database_configuration[Rails.env]
+    config['reaping_frequency'] = ENV['DB_REAP_FREQ'] || 10 # seconds
+    config['pool']              = ENV['DB_POOL'] || 20
+    ActiveRecord::Base.establish_connection(config)
+  end
+end


### PR DESCRIPTION
Partially addresses issue #90 

Add a database connection initializer as per Heroku's docs on connection pool timeouts.

https://devcenter.heroku.com/articles/concurrency-and-database-connections
