### PR TITLE
Fix grid item height in coaches grid

### DIFF
--- a/app/assets/stylesheets/event.css.sass
+++ b/app/assets/stylesheets/event.css.sass
@@ -56,3 +56,5 @@
 .highlight
   color: $red-tone
 
+ul.coaches li
+  height: 150px


### PR DESCRIPTION
This adds a height attribute to the individual coach spans in the coaches grid so it doesn't look horrible with multiple rows.
