### PR TITLE
Refactor registrations controller

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,7 +2,7 @@ class RegistrationsController < ApplicationController
   before_filter :setup_properties
 
   def new
-    if @event.registration_ends_on and @event.registration_ends_on > Date.today
+    if @event.accepting_registrations?
       @registration = @event.registrations.build
     else
       redirect_to city_event_path(@city, @event)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,4 +27,9 @@ class Event < ActiveRecord::Base
     "#{self.starts_on.strftime("%d")}-#{self.ends_on.strftime("%d")} #{self.starts_on.strftime("%B %Y")}"
   end
 
+  def accepting_registrations?
+    return true unless registration_ends_on.present?
+    registration_ends_on.future?
+  end
+
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -31,4 +31,30 @@ describe Event do
 
     end
   end
+
+  describe "#accepting_registrations?" do
+    let(:event) { Event.new(registration_ends_on: date) }
+
+    subject { event.accepting_registrations? }
+
+    context "no registration deadline" do
+      let(:date) { nil }
+      it { should be_true }
+    end
+
+    context "deadline in future" do
+      let(:date) { 2.days.from_now }
+      it { should be_true }
+    end
+
+    context "deadline today" do
+      let(:date) { Date.today }
+      it { should be_false }
+    end
+
+    context "deadline in the past" do
+      let(:date) { Date.yesterday }
+      it { should be_false }
+    end
+  end
 end


### PR DESCRIPTION
Just a couple of things I saw whilst looking through the code.
- Go through the registration association of the event to init registrations
- Move logic that determines whether registrations are being accepted to the event model

The `accepting_registrations?` method has the same logic as was in the controller before (though please double check!). This logic says that if today is the registration deadline, then **do not** accept new registrations, is this correct?

I'm not sure what I think about the whole Given/When/Then stuff in rspec, at any rate I don't really understand how to use it, so I just used plain vanilla rspec for the tests. I'm happy for someone to educate me on the new fangled Given/When/Then stuff though.
