### PR TITLE
CSS Fix for Sponsor logos appearing with borders transparent PNG is used

### DIFF
--- a/app/assets/stylesheets/meeting.css.sass
+++ b/app/assets/stylesheets/meeting.css.sass
@@ -1,3 +1,7 @@
 .sponsor
   width: 100px
   margin: 10px
+
+.sponsors
+  a
+    border: 0


### PR DESCRIPTION
This PR removes the border for sponsors logos when a transparent PNG is used.
