### PR TITLE
Fix failing specs

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -5,7 +5,6 @@ class AdminMailer < ActionMailer::Base
   include Extentions::MailerHelper
 
   def notify invitation
-
     setup invitation
 
     subject = "RSVP from #{invitation.invitee.name}"
@@ -16,17 +15,16 @@ class AdminMailer < ActionMailer::Base
 
   private
 
-
-  def mail_args(subject)
+  def mail_args(subject, participant_email = nil)
     { :to => "railsgirlslondon@gmail.com",
       :subject => subject }
   end
 
-    def load_attachments
-      %w{railsgirls-heart.png  railsgirls-london.png}.each do |image|
-        attachments.inline[image] = File.read("#{Rails.root.to_s}/app/assets/images/#{image}")
-      end
+  def load_attachments
+    %w{railsgirls-heart.png  railsgirls-london.png}.each do |image|
+      attachments.inline[image] = File.read("#{Rails.root.to_s}/app/assets/images/#{image}")
     end
+  end
 
   def setup invitation
     @invitation = invitation

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -8,7 +8,7 @@ class EventMailer < ActionMailer::Base
     setup event, registration, invitation
 
     subject = "You are invited to the Rails Girls London workshop on the #{event.dates}"
-    send_email(subject)
+    send_email(subject, registration.email)
   end
 
   def confirm_attendance event, registration, invitation
@@ -18,21 +18,21 @@ class EventMailer < ActionMailer::Base
 
     attach_ical_file(event)
 
-    send_email(subject)
+    send_email(subject, registration.email)
   end
 
   def invitation_reminder event, registration, invitation
     setup event, registration, invitation
 
     subject = "Rails Girls London - Please RSVP your attendance"
-    send_email(subject)
+    send_email(subject, registration.email)
   end
 
   def confirm_feedback event, registration, invitation
     setup event, registration, invitation
 
     subject = "RGL - Thank you for your feedback for #{@event.title} #{@event.dates}!"
-    send_email(subject)
+    send_email(subject, registration.email)
   end
 
   private

--- a/app/mailers/meeting_mailer.rb
+++ b/app/mailers/meeting_mailer.rb
@@ -7,7 +7,7 @@ class MeetingMailer < ActionMailer::Base
   def invite meeting, registration, invitation
     setup meeting, registration, invitation
     subject = "Rails Girls London - You are invited to Weeklies (#{@meeting.date.to_formatted_s(:long_ordinal)})"
-    send_email(subject)
+    send_email(subject, registration.email)
   end
 
   def confirm_attendance meeting, registration, invitation

--- a/app/views/event_mailer/confirm_attendance.html.haml
+++ b/app/views/event_mailer/confirm_attendance.html.haml
@@ -21,13 +21,4 @@
     %p.lead{ style: "font-size: 15px; color: #4E5563; margin-top: 25px;" }
       %strong See you at the workshop!
 
-  .bottom{ style: "width: 100%; padding: 50px 0 0 0px; display: block;" }
-    %strong Sponsors:
-    %br
-    = image_tag attachments['square_enix.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px "
-    = image_tag attachments['lost_my_name.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments['shutl.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments["skype.jpg"].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments['magnetic.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments["zendesk.png"].url, width: '150px', style: "display: inline-block"
-    = image_tag attachments["which.png"].url, width: '150px', style: "display: inline-block"
+  = render 'sponsor/email_logos'

--- a/app/views/event_mailer/invite.html.haml
+++ b/app/views/event_mailer/invite.html.haml
@@ -54,13 +54,4 @@
       %strong Thank you
       for applying to our Rails Girls London workshop!
 
-  .bottom{ style: "width: 100%; padding: 50px 0 0 0px; display: block;" }
-    %strong Sponsors:
-    %br
-    = image_tag attachments['square_enix.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px "
-    = image_tag attachments['lost_my_name.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments['shutl.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments["skype.jpg"].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments['magnetic.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments["zendesk.png"].url, width: '150px', style: "display: inline-block"
-    = image_tag attachments["which.png"].url, width: '150px', style: "display: inline-block"
+  = render 'sponsor/email_logos'

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -12,6 +12,11 @@
             %br
             = link_to "View more details & apply", event_path(@upcoming_event.first), class: "btn btn-primary btn-lg btn-hero"
 
+.container
+  .row
+    .col-md-12
+      = render 'layouts/messages'
+
 .section.separator.title
   .container
     .row

--- a/app/views/invitation/workshop.html.haml
+++ b/app/views/invitation/workshop.html.haml
@@ -4,6 +4,9 @@
     %strong=@invitable.title
     %small=@invitable.dates
 .row
+  .span12
+    = render 'layouts/messages'
+.row
   .span6
     %br
     %p.lead

--- a/app/views/registration_mailer/application_received.html.haml
+++ b/app/views/registration_mailer/application_received.html.haml
@@ -21,10 +21,4 @@
       %highlight{ style: "color: #E0330c" }You learn
       designing, prototyping and coding with the help of our coaches.
 
-  .bottom{ style: "width: 100%; padding: 50px 0 0 0px; display: block;" }
-    %strong Sponsors:
-    %br
-    = image_tag attachments["skype.jpg"].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments["skyscanner.png"].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments['shutl.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
-    = image_tag attachments['cake.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
+  = render 'sponsor/email_logos'

--- a/app/views/sponsor/_email_logos.html.haml
+++ b/app/views/sponsor/_email_logos.html.haml
@@ -1,0 +1,7 @@
+.bottom{ style: "width: 100%; padding: 50px 0 0 0px; display: block;" }
+  %strong Sponsors:
+  %br
+    = image_tag attachments["skype.jpg"].url, width: '150px', style: "display: inline-block; padding-right: 10px"
+    = image_tag attachments["skyscanner.png"].url, width: '150px', style: "display: inline-block; padding-right: 10px"
+    = image_tag attachments['shutl.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"
+    = image_tag attachments['cake.png'].url, width: '150px', style: "display: inline-block; padding-right: 10px"

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -16,7 +16,7 @@ describe RegistrationsController, :type => :controller do
               registration: {}
       }
 
-      Then { expect(response).to render_template(:new) }
+      Then { expect(response).to render_template('events/show') }
       And  { expect(assigns(:registration).errors).not_to be_empty }
     end
 

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -24,7 +24,7 @@ feature "viewing an event" do
         visit event_path(event)
       end
 
-      Then { page.has_content? "Apply to the event." }
+      Then { page.has_content? "Apply to the event" }
       And { page.has_content? host.name }
       And { page.has_content? "A house" }
       And { page.has_content? "123 Street st" }

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -4,6 +4,7 @@ feature "Unsubscribe from emails" do
 
   let!(:member) { Fabricate(:member, active: true) }
   let!(:event) { Fabricate(:event) }
+  let!(:host) { Fabricate(:hosting, sponsorable_type: 'Event', sponsorable_id: event.id) }
 
   specify do
     visit unsubscribe_path(member.uuid)

--- a/spec/features/visit_homepage_spec.rb
+++ b/spec/features/visit_homepage_spec.rb
@@ -4,12 +4,14 @@ feature "A user visits the homepage" do
 
   context "when there are events coming up" do
     let!(:event) { Fabricate(:event) }
+    let!(:host) { Fabricate(:hosting, sponsorable_type: 'Event', sponsorable_id: event.id) }
 
     scenario "he can view the upcoming events" do
       visit root_path
 
       expect(page).to have_content event.dates
-      expect(page).to have_content "Application"
+      expect(page).to have_content "Rails Girls London"
+      expect(page).to have_content "Making technology more approachable for women"
     end
   end
 end


### PR DESCRIPTION
This PR fixes the failing specs to fix #212 

- Update usage of mail helper to include participant email
- Fix issue with admin_mailer implementation of mail_args requiring a different number of arguments
- Extract sponsor logos to a partial and make consistent across all email templates (to match application_received email)
- Update a number of pieces of text in the specs to match the new view templates
- Update the creation of events to include a host for two of the specs
- Update the home view and invitation workshop view to render the messages partial