### PR TITLE
Redirect /london URLs to root path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ RailsgirlsLondon::Application.routes.draw do
 
   get 'home' => 'home#index'
   get "/404", to: "errors#not_found"
+  get "/london(/:slug)", to: redirect("/"), slug: /.*/
 
   #get "/:id/sponsor" => "home#sponsors", as: :city_sponsor
 


### PR DESCRIPTION
I believe this should fix #211

Tested and redirects:

- `/london/events/6`
- `/london/sponsors`

Does not redirect for valid urls not containing the word 'London', such as the unsubscribe URL.