### PR TITLE
Display a count of coaches for an event on the admin panel.

### DIFF
--- a/app/views/admin/shared/_coaches.html.haml
+++ b/app/views/admin/shared/_coaches.html.haml
@@ -1,5 +1,5 @@
 %legend
-  Coaches
+  Coaches (#{coachable.coaches.count})
   %small= link_to "Add coach", new_admin_coach_path
 
 - if coachable.coaches.any?

--- a/app/views/admin/shared/_registrations.html.haml
+++ b/app/views/admin/shared/_registrations.html.haml
@@ -1,5 +1,5 @@
 %legend
-  Registrations
+  Registrations (#{@event.registrations.count})
   %small= link_to "Add registration", new_admin_event_registration_path(@event)
 
 - if @event.registrations.any?

--- a/app/views/admin/shared/_sponsors.html.haml
+++ b/app/views/admin/shared/_sponsors.html.haml
@@ -1,5 +1,5 @@
 %legend
-  Sponsors
+  Sponsors (#{sponsorable.sponsors.count})
   %small= link_to "Add sponsor", new_admin_sponsor_path
 
 - if sponsorable.sponsors.any?


### PR DESCRIPTION
_See issue #218._

This PR adds a simple count on the admin panel for coaches, sponsors, and registrations.

<img width="387" alt="screen shot 2015-10-28 at 22 11 35" src="https://cloud.githubusercontent.com/assets/244541/10808369/128f5c54-7dc1-11e5-877f-3dd33406292f.png">