### PR TITLE
Some more options for the gender selection on signup, & make it optional.

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -35,7 +35,7 @@ class Registration < ActiveRecord::Base
   )
 
   validates *REQUIRED_ATTRIBUTES,     presence: true
-  validates *REGISTRATION_ATTRIBUTES, presence: true, on: :registration
+  validates *(REGISTRATION_ATTRIBUTES - [:gender]), presence: true, on: :registration
 
   belongs_to :event
   belongs_to :member

--- a/app/views/registrations/_student_form.html.haml
+++ b/app/views/registrations/_student_form.html.haml
@@ -4,7 +4,7 @@
     = simple_form_for @registration, url: event_registrations_path(@event), html: { class: 'form-horizontal' } , remote: true do |f|
       = f.input :first_name, input_html: {class: "form-control"}
       = f.input :last_name, input_html: {class: "form-control"}
-      = f.input :gender, collection: [ "Female", "Male" ], prompt: "Select your gender", input_html: {class: "form-control"}
+      = f.input :gender, collection: [ "Female", "Male", "Other", "I prefer not to say" ], prompt: "Select your gender", input_html: {class: "form-control"}
       %hr
       = f.input :email, input_html: {class: "form-control"}
       = f.input :email_confirmation, input_html: {class: "form-control"}

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -16,7 +16,7 @@ describe RegistrationsController, :type => :controller do
               registration: {}
       }
 
-      Then { expect(response).to render_template(:new) }
+      Then { expect(response).to render_template("events/show") }
       And  { expect(assigns(:registration).errors).not_to be_empty }
     end
 

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -14,6 +14,7 @@ feature "a girl registering" do
   let(:preferred_language) { Faker::Lorem.sentence }
   let(:os_version) { Faker::Lorem.sentence }
   let(:dietary_restrictions) { Faker::Lorem.sentence }
+  let(:how_you_heard) { Faker::Lorem.sentence }
 
 
   Given!(:event) { Fabricate(:event) }
@@ -38,7 +39,8 @@ feature "a girl registering" do
       select "OS X", from: "Operating System"
       fill_in "OS Version", with: os_version
       fill_in "Programming experience", with: experience
-      fill_in "Reason for applying", with: reason
+      fill_in "Why are you applying?", with: reason
+      fill_in "How did you hear about us?", with: how_you_heard
       check('registration_terms_of_service')
 
       click_on "Apply"

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -28,7 +28,6 @@ feature "a girl registering" do
     When do
       fill_in "First name", with: first_name
       fill_in "Last name", with: last_name
-      select "Female", from: "Gender"
       fill_in 'registration_email', with: email
       fill_in "Email confirmation", with: email
       fill_in "Phone number", with: phone_number
@@ -44,6 +43,34 @@ feature "a girl registering" do
       check('registration_terms_of_service')
 
       click_on "Apply"
+    end
+
+    Then { page.has_content? "Thanks for applying to our workshop.You should receive a confirmation email soon!" }
+  end
+
+  context "With all fields filled in" do
+    When do
+      fill_in "First name", with: first_name
+      fill_in "Last name", with: last_name
+      select gender, from: "Gender"
+      fill_in 'registration_email', with: email
+      fill_in "Email confirmation", with: email
+      fill_in "Phone number", with: phone_number
+      fill_in "Twitter", with: twitter
+      fill_in "Address", with: address
+      fill_in "Spoken languages", with: spoken_languages
+      fill_in "Preferred language", with: preferred_language
+      select "Yes", from: "UK Resident"
+      select "OS X", from: "Operating System"
+      fill_in "OS Version", with: os_version
+      fill_in "Programming experience", with: experience
+      fill_in "Why are you applying?", with: reason
+      fill_in "How did you hear about us?", with: how_you_heard
+      fill_in "What are your dietary restrictions (if any)?", with: dietary_restrictions
+      check('registration_terms_of_service')
+
+      click_on "Apply"
+
     end
 
     Then { page.has_content? "Thanks for applying to our workshop.You should receive a confirmation email soon!" }


### PR DESCRIPTION
_A fix for #221._

This changeset makes the `:gender` field on registrations optional, and adds a couple of options listed in issue #221. I'm not aware of the wider discussions around this, but I took the liberty of changing "I don't want to say" to "I prefer not to say", which seems a little friendlier to me. If that's a problem let me know & I'll switch it to the exact language in #221. 

There's also a couple of fixes to the test suite in this changeset, though it's still got quite a lot of failures in it. 