### PR TITLE
Only allow a student to register once per event.

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -41,7 +41,8 @@ class Registration < ActiveRecord::Base
   belongs_to :member
 
   validates :terms_of_service, :acceptance => true
-  validates :email,            :confirmation => true
+  validates :email, confirmation: true
+  validates :email, uniqueness: { scope: :event_id, message: "can only register once per event" }
 
   scope :accepted, -> { where(selection_state: "accepted", attending: true) }
   scope :members,  -> { where(Registration.arel_table[:member_id].not_eq(nil)) }

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -42,7 +42,7 @@ class Registration < ActiveRecord::Base
 
   validates :terms_of_service, :acceptance => true
   validates :email, confirmation: true
-  validates :email, uniqueness: { scope: :event_id, message: "can only register once per event" }
+  validates :email, uniqueness: { scope: :event_id, message: "You've already registered for this event! Sit tight, you'll hear from us soon." }
 
   scope :accepted, -> { where(selection_state: "accepted", attending: true) }
   scope :members,  -> { where(Registration.arel_table[:member_id].not_eq(nil)) }

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -47,8 +47,26 @@ describe Registration do
 
       expect(invalid_registration.valid?(:registration)).to be false
       Registration::REGISTRATION_ATTRIBUTES.each do |attribute|
+        next if attribute == :gender
         expect(invalid_registration.errors[attribute]).not_to be_empty
       end
+    end
+
+    it "Only allows one registration per email address for each event" do
+      member = Fabricate(:member)
+      event = Fabricate(:event)
+      first_registration = Fabricate(:registration, event: event, email: member.email)
+      expect(first_registration).to be_valid
+
+      second_registration = Fabricate.build(:registration, event: event, email: member.email)
+      expect(second_registration).not_to be_valid
+    end
+
+    it "Allows an email address to register for multiple events" do
+      member = Fabricate(:member)
+      event_1, event_2 = Fabricate.times(2, :event)
+      expect(Fabricate(:registration, event: event_1, email: member.email)).to be_valid
+      expect(Fabricate(:registration, event: event_2, email: member.email)).to be_valid
     end
   end
 


### PR DESCRIPTION
_See also #202._

This changeset adds a validator to make sure that a student can only register once per event. If they're already registered, they'll see a friendly message when they click 'Apply':

<img width="573" alt="screen shot 2015-11-04 at 18 43 43" src="https://cloud.githubusercontent.com/assets/244541/10955780/49c8141e-8324-11e5-913f-754f03deb1c0.png">


It also fixes another test failure that is a result of my changes in #221. This is the second time I've broken the tests; sorry. 