### PR TITLE
Prevent duplicate submissions by disabling submit button after first click.

### DIFF
--- a/app/views/registrations/_student_form.html.haml
+++ b/app/views/registrations/_student_form.html.haml
@@ -69,4 +69,4 @@
       %hr
 
       .form-actions
-        = f.submit "Apply", class: "btn btn-primary btn-lg btn-hero"
+        = f.submit "Apply", class: "btn btn-primary btn-lg btn-hero", data: { disable_with: "Please wait..." }


### PR DESCRIPTION
_See also #201._

Rails' unobtrusive JavaScript [supports a `disabled_with` parameter](http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-submit_tag) on remote forms. This disables the button and replaces the caption on the button while the form's being submitted.