### PR TITLE
Fix scrolly links (& associated highlighting)

### DIFF
--- a/app/assets/javascripts/googlemaps.js
+++ b/app/assets/javascripts/googlemaps.js
@@ -1,14 +1,19 @@
 var map;
 function initialize() {
-  geocoder = new google.maps.Geocoder();
-  var latlng = new google.maps.LatLng(0, 0);
-  var mapOptions = {
-    zoom: 12,
-    center: latlng,
-    mapTypeId: google.maps.MapTypeId.ROADMAP
+  var map_element = document.getElementById('map-canvas');
+
+  if (map_element) {
+    geocoder = new google.maps.Geocoder();
+    var latlng = new google.maps.LatLng(0, 0);
+    var mapOptions = {
+      zoom: 12,
+      center: latlng,
+      mapTypeId: google.maps.MapTypeId.ROADMAP
+    }
+
+    map = new google.maps.Map(map_element, mapOptions);
+    codeAddress();
   }
-  map = new google.maps.Map(document.getElementById('map-canvas'), mapOptions);
-  codeAddress();
 }
 
 function codeAddress() {

--- a/app/assets/javascripts/scroll.js
+++ b/app/assets/javascripts/scroll.js
@@ -1,11 +1,5 @@
-var ready;
-
-ready = function() {
-  scrollNav();
-};
-
 function scrollNav() {
-  $('.nav a, #apply-student-btn').click(function(){
+  $('.nav a, #apply-student-btn').click(function() {
     $(".active").removeClass("active");
     $(this).closest('li').addClass("active");
     var theClass = $(this).attr("class");
@@ -18,5 +12,5 @@ function scrollNav() {
   $('.scrollTop a').scrollTop();
 }
 
-$(document).ready(ready);
-$(document).on('page:load', ready);
+$(document).ready(scrollNav);
+$(document).on('page:load', scrollNav);


### PR DESCRIPTION
_Fixes #200._

The Google Maps JavaScript was presuming that there would be an element on the page for it to use. If there wasn't an element, then it would result in a JavaScript error. This, in turn, breaks all the remaining JavaScript.