### PR TITLE
Order registrations by creation date by default.

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -47,6 +47,8 @@ class Registration < ActiveRecord::Base
   scope :accepted, -> { where(selection_state: "accepted", attending: true) }
   scope :members,  -> { where(Registration.arel_table[:member_id].not_eq(nil)) }
 
+  default_scope -> { order(created_at: :desc) }
+
   def fullname
     "#{first_name} #{last_name}"
   end


### PR DESCRIPTION
_Should fix #216._

This adds a `default_scope` to the `Registration` that orders by date, newest first. This should be a valid fix for #216, unless there's some parts of the app that display lists of registrations I don't know about.