### PR TITLE
Closes #205 - Added #RailsGirlsLDN

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,6 +53,6 @@ module ApplicationHelper
   private
 
   def railsgirls_twitter_widget_id
-    "380105070089490433"
+    "668501816531922944"
   end
 end


### PR DESCRIPTION
Twitter's search widget can only show the last 7 days of history (as opposed to an account widget that has unlimited history). So I created a new search widget using this query
> from:@railsgirls_ldn OR from:@railsgirls OR #railsgirlsldn
and replaced the widget id in the codebase.
As far as I can tell, there's no way to show both @railsgirls tweets and #railsgirlsldn tweets in the same widget, so the results will be limited to 7 days only.