### PR TITLE
Closes #210 - Added default image for gravatar url

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,7 @@ module ApplicationHelper
   end
 
   def gravatar_url(email,size=50)
-    "http://gravatar.com/avatar/#{md5(email)}?s=#{size}"
+    "http://gravatar.com/avatar/#{md5(email)}?s=#{size}&d=https://raw.githubusercontent.com/railsgirlslondon/railsgirls-london/master/app/assets/images/avatar50px.jpg"
   end
 
   def md5(string)


### PR DESCRIPTION
@hundred Added 50px default image to the gravatar url to use on the events/show page.
Since the default url must be public, I committed it directly to the railsgirls repo and used this url in this commit. I've noticed that in the code base gravatars are 35px and 90px too, so this PR will display a 50px default when 35/90px were meant to be used.
I see three ways around it:
1. Create 35px and 90px default images and make gravatar_url() method use them as needed.
2. Only use a 90px image and use CSS to resize it down when needed.
3. Update the code to always use 50px avatars across the site.

Let me know what approach you prefer and whether you want me to update this PR or open an new issue.