### PR TITLE
Add contact details to the front page of the site.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'ruby-trello', require: false
 gem 'pg'
 gem 'newrelic_rpm'
 gem 'icalendar'
+gem 'evil_icons' # SVG icon set
 
 group :production do
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       dotenv (= 2.0.2)
       railties (~> 4.0)
     erubis (2.7.0)
+    evil_icons (1.7.8)
     execjs (2.6.0)
     fabrication (2.14.1)
     faker (1.5.0)
@@ -329,6 +330,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  evil_icons
   fabrication
   faker
   guard
@@ -355,3 +357,6 @@ DEPENDENCIES
   unicorn
   vcr
   webmock (< 1.10)
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -18,6 +18,7 @@
 @import 'partials/colors'
 @import 'partials/settings'
 @import 'bootstrap-sprockets'
+@import 'evil-icons'
 
 .splash
   color: white
@@ -50,6 +51,9 @@
     color: white
     font-weight: 600
     // padding-bottom: 2rem
+
+.ei-icon
+  color: $secondary-rg-color
 
 
 footer

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -60,6 +60,21 @@
                     = image_tag sponsor.image_url
 
 
-.section
+.section.separator
   .container
     = render "sponsor/info"
+
+.section
+  .container
+    #contact
+      .row
+        .col-md-12
+          %h1 Keep in touch with us!
+          .row
+            .col-md-4
+              You can #{link_to "email us", "mailto:railsgirlslondon@gmail.com"} at #{link_to "railsgirlslondon@gmail.com", "mailto:railsgirlslondon@gmail.com"}.
+            .col-md-4
+              Join the Rails Girls community on #{link_to "Twitter", "https://twitter.com/railsgirls_ldn"}, #{link_to "Facebook", "http://www.facebook.com/railsgirlslondon"}, or #{link_to "Google+", "https://plus.google.com/104252944343767158344/"}.
+            .col-md-4
+              Join #{link_to "our student mailing list", "https://groups.google.com/forum/#!forum/rails-girls-london"} or #{link_to "our coach mailing list", "https://groups.google.com/forum/#!forum/rails-girls-london-coaches"} to stay up to date about our future events.
+

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -72,9 +72,12 @@
           %h1 Keep in touch with us!
           .row
             .col-md-4
+              = evil_icon "ei-envelope", size: :m, class: "pull-left ei-icon"
               You can #{link_to "email us", "mailto:railsgirlslondon@gmail.com"} at #{link_to "railsgirlslondon@gmail.com", "mailto:railsgirlslondon@gmail.com"}.
             .col-md-4
+              = evil_icon "ei-like", size: :m, class: "pull-left ei-icon"
               Join the Rails Girls community on #{link_to "Twitter", "https://twitter.com/railsgirls_ldn"}, #{link_to "Facebook", "http://www.facebook.com/railsgirlslondon"}, or #{link_to "Google+", "https://plus.google.com/104252944343767158344/"}.
             .col-md-4
+              = evil_icon "ei-comment", size: :m, class: "pull-left ei-icon"
               Join #{link_to "our student mailing list", "https://groups.google.com/forum/#!forum/rails-girls-london"} or #{link_to "our coach mailing list", "https://groups.google.com/forum/#!forum/rails-girls-london-coaches"} to stay up to date about our future events.
 

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -15,4 +15,4 @@
         %li
           = link_to "SPONSORS", landing_page_anchor_link("sponsors")
         %li
-          %a{ href: "mailto:railsgirlslondon@gmail.com" } CONTACT
+          = link_to "CONTACT", landing_page_anchor_link("contact")

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
     %meta{:content => "", :name => "author"}
     %script(type="text/javascript" src="http://use.typekit.net/xaz4ocu.js")
     %script(type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_KEY']}&sensor=true")
+    = evil_icons_sprite
     :javascript
       try{Typekit.load();}catch(e){}
     = stylesheet_link_tag "application", :media => "all"


### PR DESCRIPTION
As listed in #203, this changeset adds contact details to the bottom of the page. I've added some icons too, to make it a bit more visually appealing.

<img width="1143" alt="screen shot 2015-11-24 at 20 32 34" src="https://cloud.githubusercontent.com/assets/244541/11385921/78719c6e-92eb-11e5-8bec-019fb2809711.png">

