### PR TITLE
Fixed css for social icons

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.sass
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.sass
@@ -25,6 +25,8 @@ $baseFontSize: 16px
 
 .btn.icon
   font-size: 50px
+  width: auto
+  height: auto
   +darker-button($rails-girls-color)
 
 .btn-hero


### PR DESCRIPTION
The css problem was introduced by the evil_icon gems added in the PR #233. I overrode width&height settings for .icon class from the gem in a more specific selector.