### PR TITLE
A basic version of attendance tracking in the app.

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,0 +1,17 @@
+;(function($) {
+  // Hide the "Add a note..." link and show the text area.
+  var reveal_note_area = function(el) {
+    var $parent_form = $(el).closest("form");
+    $(".add-note", $parent_form).addClass("hidden");
+    $('textarea', $parent_form).removeClass("hidden");
+  };
+
+  // Attach listener to document.ready DOM event.
+  $(function() {
+    $(".add-note").on('click', function(ev) {
+      ev.preventDefault();
+      console.log(ev);
+      reveal_note_area(ev.target);
+    });
+  });
+})($);

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -6,12 +6,27 @@
     $('textarea', $parent_form).removeClass("hidden");
   };
 
+  // Filter the rows of the table down to just those that contain search_term in the name.
+  var filter_attendees = function(search_term) {
+    $("table.attendees tr").each(function(i, row) {
+      if ($("td.name", row).text().toLowerCase().indexOf(search_term.toLowerCase()) >= 0) {
+        $(row).removeClass("hidden");
+      } else {
+        $(row).addClass("hidden");
+      }
+    });
+  };
+
   // Attach listener to document.ready DOM event.
   $(function() {
     $(".add-note").on('click', function(ev) {
       ev.preventDefault();
       console.log(ev);
       reveal_note_area(ev.target);
+    });
+
+    $(".attendance-filter").on('keyup', function(ev) {
+      filter_attendees($(ev.target).val());
     });
   });
 })($);

--- a/app/assets/stylesheets/admin.css.sass
+++ b/app/assets/stylesheets/admin.css.sass
@@ -1,0 +1,2 @@
+.add-note
+  max-width: 250px

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -90,3 +90,6 @@ notice
 
 #map-canvas
   height: 300px
+
+.hidden
+  display: none

--- a/app/controllers/admin/coachings_controller.rb
+++ b/app/controllers/admin/coachings_controller.rb
@@ -29,6 +29,6 @@ class Admin::CoachingsController < ApplicationController
 
   private
     def event_coaching_params
-      params.require(:coaching).permit(:coachable_id, :coachable_type, :coach_id, :organiser)
+      params.require(:coaching).permit(:coachable_id, :coachable_type, :coach_id, :organiser, :attended, :attendance_note)
     end
 end

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -20,6 +20,17 @@ class Admin::RegistrationsController < ApplicationController
     end
   end
 
+  def update
+    @registration = Registration.find(params[:id])
+    if @registration.update_attributes(registration_params)
+      flash[:notice] = "Registration has been updated."
+    else
+      flash[:error] = @registration.errors.full_messages.join("\n")
+    end
+
+    redirect_to(:back)
+  end
+
   def show
   end
 
@@ -36,5 +47,9 @@ class Admin::RegistrationsController < ApplicationController
 
   def find_registration
     @registration = Registration.find params[:id]
+  end
+
+  def registration_params
+    params.require(:registration).permit(:attended, :attendance_note)
   end
 end

--- a/app/models/coaching.rb
+++ b/app/models/coaching.rb
@@ -2,12 +2,17 @@ class Coaching < ActiveRecord::Base
   belongs_to :coach
   belongs_to :coachable, :polymorphic => true
 
+  include Extentions::Attendable
+
+  delegate :name, to: :coach
+  delegate :email, to: :coach
+
   attr_accessible :coachable_type, :coachable_id, :coach_id, :coach, :organiser
 
   validate :coach_must_have_phone, if: :organiser?
 
   def coach_must_have_phone
-    return if coach.phone_number.present? 
+    return if coach.phone_number.present?
 
     errors.add(:coach, "must have phone number")
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ActiveRecord::Base
-  
+
   ATTRIBUTES = [
     :title,
     :description,
@@ -58,6 +58,10 @@ class Event < ActiveRecord::Base
 
   def selected_applicants
     registrations.where :selection_state => "accepted"
+  end
+
+  def attendees
+    (selected_applicants + coachings).sort_by(&:name)
   end
 
   def instruct_coaches

--- a/app/models/extentions/attendable.rb
+++ b/app/models/extentions/attendable.rb
@@ -1,0 +1,15 @@
+require 'active_support/concern'
+
+# Both students & coaches at an event can have their attendance tracked (ie. whether they showed up or not,
+# along with a note). The fields are the same in both places, so this is extracted out into a concern.
+module Extentions
+  module Attendable
+
+    extend ActiveSupport::Concern
+
+    included do
+      enum attended: [:unknown, :attended, :cancelled, :no_show]
+      attr_accessible :attended, :attendance_note
+    end
+  end
+end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,6 +1,8 @@
 class Registration < ActiveRecord::Base
   has_one :invitation, foreign_key: :invitee_id
 
+  include Extentions::Attendable # Allows for tracking whether a student showed up (and why/why not)
+
   REQUIRED_ATTRIBUTES = [
     :first_name,
     :last_name,

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -21,3 +21,4 @@
 
   =render partial: "admin/shared/registrations", locals:  { registrations: @event.registrations }
 
+  =render partial: "admin/shared/attendances", locals: { event: @event }

--- a/app/views/admin/shared/_attendances.html.haml
+++ b/app/views/admin/shared/_attendances.html.haml
@@ -1,9 +1,9 @@
 %h1 Attendance Manager
 
 %form
-  %input{placeholder: "Start typing to filter..."}
+  %input.attendance-filter{placeholder: "Start typing to filter..."}
 
-%table.table.table-striped.table-condensed
+%table.table.table-striped.table-condensed.attendees
   %thead
     %tr
       %td Name
@@ -13,7 +13,7 @@
   %tbody
     - event.attendees.each do |att|
       %tr
-        %td= att.name
+        %td.name= att.name
         %td= att.email
         %td
           - if att.is_a? Registration

--- a/app/views/admin/shared/_attendances.html.haml
+++ b/app/views/admin/shared/_attendances.html.haml
@@ -1,0 +1,39 @@
+%h1 Attendance Manager
+
+%form
+  %input{placeholder: "Start typing to filter..."}
+
+%table.table.table-striped.table-condensed
+  %thead
+    %tr
+      %td Name
+      %td Email
+      %td Type
+      %td Attendance
+  %tbody
+    - event.attendees.each do |att|
+      %tr
+        %td= att.name
+        %td= att.email
+        %td
+          - if att.is_a? Registration
+            Student
+          - elsif att.is_a? Coaching
+            Coach
+        %td
+          - registration_path_elements = att.is_a?(Registration) ? [:admin, event, att] : [:admin, att]
+          = simple_form_for registration_path_elements, html: { class: "form-inline" } do |f|
+            .row
+              = f.select :attended, att.class.attendeds.keys.to_a.map { |w| [w.humanize, w] }
+              = f.submit "Save", class: "btn"
+            .row
+              - if att.attendance_note.blank?
+                = link_to "Add note...", "#", class: "add-note"
+              - else
+                .add-note
+                  Note:
+                  = att.attendance_note
+                  = link_to "Edit...", "#", class: "add-note"
+              = f.text_area :attendance_note, placeholder: "Add a note...", class: "hidden"
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ RailsgirlsLondon::Application.routes.draw do
       resources :invitations, only: [ :show ], :invitable_type => 'Event', :invitable_id => 'event_id' do
         post 'create', on: :collection
       end
-      resources :registrations, only: [:show, :new, :create, :destroy] do
+      resources :registrations, only: [:show, :new, :create, :update, :destroy] do
         resource :attendance, only: [:create, :destroy]
       end
     end

--- a/db/migrate/20151125024505_add_attendance_to_registration.rb
+++ b/db/migrate/20151125024505_add_attendance_to_registration.rb
@@ -1,0 +1,6 @@
+class AddAttendanceToRegistration < ActiveRecord::Migration
+  def change
+    add_column :registrations, :attended, :integer
+    add_column :registrations, :attendance_note, :text
+  end
+end

--- a/db/migrate/20151202022635_add_attendance_to_coaching.rb
+++ b/db/migrate/20151202022635_add_attendance_to_coaching.rb
@@ -1,0 +1,6 @@
+class AddAttendanceToCoaching < ActiveRecord::Migration
+  def change
+    add_column :coachings, :attended, :integer
+    add_column :coachings, :attendance_note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151029023554) do
+ActiveRecord::Schema.define(version: 20151202022635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 20151029023554) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "organiser"
+    t.integer  "attended"
+    t.text     "attendance_note"
   end
 
   add_index "coachings", ["coach_id"], name: "index_coachings_on_coach_id", using: :btree
@@ -169,6 +171,8 @@ ActiveRecord::Schema.define(version: 20151029023554) do
     t.boolean  "attending",                 default: false, null: false
     t.integer  "member_id"
     t.text     "how_did_you_hear_about_us"
+    t.integer  "attended"
+    t.text     "attendance_note"
   end
 
   add_index "registrations", ["email"], name: "index_registrations_on_email", using: :btree


### PR DESCRIPTION
_See also #214._

So, this is not code I'm proud of. But I said I'd have a go at this task, and the next RGL is a week away. Thus, I thought I'd send a pull request so you folk could decide if it's useful enough to be worth merging before the next event.

This changeset adds some basic attendance tracking to the app, for both coaches and students. There's a number of statuses to choose from for an attendee, as well as the ability to have a per-event note. This is stored on the `Registration` for students, and on `Coaching` for coaches. There's also a nifty little "find attendee" filter, that uses JavaScript to help you find the person you're trying to update.

It sucks because: 
- There are no tests
- The visual design is rather lacking (and there's a sneaky little CSS `max-width` to stop huge notes busting the table size).
- There's some rather long chains of logic in the templates
- It does some "type sniffing" to determine the correct behaviour.

![attendance_demo](https://cloud.githubusercontent.com/assets/244541/11522520/cd3f6236-9885-11e5-8ff8-331d09dfd74c.gif)
