### PR TITLE
Update deprecated rspec

### DIFF
--- a/spec/controllers/admin/coaches_controller_spec.rb
+++ b/spec/controllers/admin/coaches_controller_spec.rb
@@ -57,23 +57,23 @@ describe Admin::CoachesController, :type => :controller do
 
       it "redirects to the created coach" do
         post :create, {:coach => valid_attributes}, valid_session
-        response.should redirect_to([:admin, Coach.last])
+        expect(response).to redirect_to([:admin, Coach.last])
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved coach as @coach" do
         # Trigger the behavior that occurs when invalid params are submitted
-        Coach.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Coach).to receive(:save).and_return(false)
         post :create, {:coach => { "name" => "invalid value" }}, valid_session
         expect(assigns(:coach)).to be_a_new(Coach)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
-        Coach.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Coach).to receive(:save).and_return(false)
         post :create, {:coach => { "name" => "invalid value" }}, valid_session
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end
@@ -86,7 +86,7 @@ describe Admin::CoachesController, :type => :controller do
         # specifies that the Coach created on the previous line
         # receives the :update_attributes message with whatever params are
         # submitted in the request.
-        Coach.any_instance.should_receive(:update).with({ "name" => "MyString" })
+        expect_any_instance_of(Coach).to receive(:update).with({ "name" => "MyString" })
         put :update, {:id => coach.to_param, :coach => { "name" => "MyString" }}, valid_session
       end
 
@@ -99,7 +99,7 @@ describe Admin::CoachesController, :type => :controller do
       it "redirects to the coach" do
         coach = Coach.create! valid_attributes
         put :update, {:id => coach.to_param, :coach => valid_attributes}, valid_session
-        response.should redirect_to([:admin, coach])
+        expect(response).to redirect_to([:admin, coach])
       end
     end
 
@@ -107,7 +107,7 @@ describe Admin::CoachesController, :type => :controller do
       it "assigns the coach as @coach" do
         coach = Coach.create! valid_attributes
         # Trigger the behavior that occurs when invalid params are submitted
-        Coach.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Coach).to receive(:save).and_return(false)
         put :update, {:id => coach.to_param, :coach => { "name" => "invalid value" }}, valid_session
         expect(assigns(:coach)).to eq(coach)
       end
@@ -115,9 +115,9 @@ describe Admin::CoachesController, :type => :controller do
       it "re-renders the 'edit' template" do
         coach = Coach.create! valid_attributes
         # Trigger the behavior that occurs when invalid params are submitted
-        Coach.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Coach).to receive(:save).and_return(false)
         put :update, {:id => coach.to_param, :coach => { "name" => "invalid value" }}, valid_session
-        response.should render_template("edit")
+        expect(response).to render_template("edit")
       end
     end
   end
@@ -133,7 +133,7 @@ describe Admin::CoachesController, :type => :controller do
     it "redirects to the coaches list" do
       coach = Coach.create! valid_attributes
       delete :destroy, {:id => coach.to_param}, valid_session
-      response.should redirect_to(admin_coaches_path)
+      expect(response).to redirect_to(admin_coaches_path)
     end
   end
 

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -13,7 +13,7 @@ describe Admin::EventsController, :type => :controller do
     it "assigns all events as @events" do
       event = Event.create! valid_attributes
       get :index, {}
-      assigns(:events).should eq([event])
+      expect(assigns(:events)).to eq([event])
     end
   end
 
@@ -21,14 +21,14 @@ describe Admin::EventsController, :type => :controller do
     it "assigns the requested event as @event" do
       event = Event.create! valid_attributes
       get :show, {:id => event.to_param}
-      assigns(:event).should eq(event)
+      expect(assigns(:event)).to eq(event)
     end
   end
 
   describe "GET new" do
     it "assigns a new event as @event" do
       get :new, {}
-      assigns(:event).should be_a_new(Event)
+      expect(assigns(:event)).to be_a_new(Event)
     end
   end
 
@@ -36,7 +36,7 @@ describe Admin::EventsController, :type => :controller do
     it "assigns the requested event as @event" do
       event = Event.create! valid_attributes
       get :edit, {:id => event.to_param}
-      assigns(:event).should eq(event)
+      expect(assigns(:event)).to eq(event)
     end
   end
 
@@ -50,7 +50,7 @@ describe Admin::EventsController, :type => :controller do
 
       it "redirects to the created event" do
         post :create, {:event => valid_attributes}
-        response.should redirect_to([:admin, Event.last])
+        expect(response).to redirect_to([:admin, Event.last])
       end
     end
 
@@ -61,11 +61,11 @@ describe Admin::EventsController, :type => :controller do
       end
 
       it "assigns a newly created but unsaved event as @event" do
-        assigns(:event).should be_a_new(Event)
+        expect(assigns(:event)).to be_a_new(Event)
       end
 
       it "re-renders the 'new' template" do
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end
@@ -81,13 +81,13 @@ describe Admin::EventsController, :type => :controller do
       it "assigns the requested event as @event" do
         event = Event.create! valid_attributes
         put :update, {:id => event.to_param, :event => valid_attributes}
-        assigns(:event).should eq(event)
+        expect(assigns(:event)).to eq(event)
       end
 
       it "redirects to the event" do
         event = Event.create! valid_attributes
         put :update, {:id => event.to_param, :event => valid_attributes}
-        response.should redirect_to([:admin, event])
+        expect(response).to redirect_to([:admin, event])
       end
     end
 
@@ -97,14 +97,14 @@ describe Admin::EventsController, :type => :controller do
         # Trigger the behavior that occurs when invalid params are submitted
         allow_any_instance_of(Event).to receive(:save).and_return(false)
         put :update, {:id => event.to_param, :event => { "description" => "invalid value" }}
-        assigns(:event).should eq(event)
+        expect(assigns(:event)).to eq(event)
       end
 
       it "re-renders the 'edit' template" do
         event = Event.create! valid_attributes
         allow_any_instance_of(Event).to receive(:save).and_return(false)
         put :update, {:id => event.to_param, :event => { "description" => "invalid value" }}
-        response.should render_template("edit")
+        expect(response).to render_template("edit")
       end
     end
   end
@@ -120,7 +120,7 @@ describe Admin::EventsController, :type => :controller do
     it "redirects to the events list" do
       event = Event.create! valid_attributes
       delete :destroy, {:id => event.to_param}
-      response.should redirect_to(admin_events_path)
+      expect(response).to redirect_to(admin_events_path)
     end
   end
 

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -56,7 +56,7 @@ describe Admin::EventsController, :type => :controller do
 
     describe "with invalid params" do
       before do
-        Event.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Event).to receive(:save).and_return(false)
         post :create, {:event => { :wrong_params => true  }}
       end
 
@@ -74,7 +74,7 @@ describe Admin::EventsController, :type => :controller do
     describe "with valid params" do
       it "updates the requested event" do
         event = Event.create! valid_attributes
-        Event.any_instance.should_receive(:update_attributes).with({ "description" => "MyString" })
+        expect_any_instance_of(Event).to receive(:update_attributes).with({ "description" => "MyString" })
         put :update, {:id => event.to_param, :event => { "description" => "MyString" }}
       end
 
@@ -95,14 +95,14 @@ describe Admin::EventsController, :type => :controller do
       it "assigns the event as @event" do
         event = Event.create! valid_attributes
         # Trigger the behavior that occurs when invalid params are submitted
-        Event.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Event).to receive(:save).and_return(false)
         put :update, {:id => event.to_param, :event => { "description" => "invalid value" }}
         assigns(:event).should eq(event)
       end
 
       it "re-renders the 'edit' template" do
         event = Event.create! valid_attributes
-        Event.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Event).to receive(:save).and_return(false)
         put :update, {:id => event.to_param, :event => { "description" => "invalid value" }}
         response.should render_template("edit")
       end

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -66,14 +66,14 @@ describe Admin::MembersController, :type => :controller do
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved member as @member" do
-        Member.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Member).to receive(:save).and_return(false)
         post :create, {:member => { "name" => "invalid value" }}, valid_session
 
         assigns(:member).should be_a_new(Member)
       end
 
       it "re-renders the 'new' template" do
-        Member.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Member).to receive(:save).and_return(false)
         post :create, {:member => { "name" => "invalid value" }}, valid_session
 
         response.should render_template("new")
@@ -85,7 +85,7 @@ describe Admin::MembersController, :type => :controller do
     describe "with valid params" do
       it "updates the requested member" do
         member = Member.create! valid_attributes
-        Member.any_instance.should_receive(:update).with({ "first_name" => "MyString" })
+        expect_any_instance_of(Member).to receive(:update).with({ "first_name" => "MyString" })
 
         put :update, {:id => member.to_param, :member => { "first_name" => "MyString" }}, valid_session
       end
@@ -108,7 +108,7 @@ describe Admin::MembersController, :type => :controller do
     describe "with invalid params" do
       it "re-renders the 'edit' template" do
         member = Member.create! valid_attributes
-        Member.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Member).to receive(:save).and_return(false)
         put :update, {:id => member.to_param, :member => { "wrong_param" => "invalid value" }}, valid_session
 
         response.should render_template("edit")

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -14,7 +14,7 @@ describe Admin::MembersController, :type => :controller do
     it "assigns all members as @members" do
       member = Member.create! valid_attributes
       get :index, {}, valid_session
-      assigns(:members).should eq([member])
+      expect(assigns(:members)).to eq([member])
     end
   end
 
@@ -22,14 +22,14 @@ describe Admin::MembersController, :type => :controller do
     it "assigns the requested member as @member" do
       member = Member.create! valid_attributes
       get :show, {:id => member.to_param}, valid_session
-      assigns(:member).should eq(member)
+      expect(assigns(:member)).to eq(member)
     end
   end
 
   describe "GET new" do
     it "assigns a new member as @member" do
       get :new, {}, valid_session
-      assigns(:member).should be_a_new(Member)
+      expect(assigns(:member)).to be_a_new(Member)
     end
   end
 
@@ -38,7 +38,7 @@ describe Admin::MembersController, :type => :controller do
       member = Member.create! valid_attributes
       get :edit, {:id => member.to_param}, valid_session
 
-      assigns(:member).should eq(member)
+      expect(assigns(:member)).to eq(member)
     end
   end
 
@@ -53,14 +53,14 @@ describe Admin::MembersController, :type => :controller do
       it "assigns a newly created member as @member" do
         post :create, {:member => valid_attributes}, valid_session
 
-        assigns(:member).should be_a(Member)
-        assigns(:member).should be_persisted
+        expect(assigns(:member)).to be_a(Member)
+        expect(assigns(:member)).to be_persisted
       end
 
       it "redirects to the members index" do
         post :create, {:member => valid_attributes}, valid_session
 
-        response.should redirect_to([:admin, :members])
+        expect(response).to redirect_to([:admin, :members])
       end
     end
 
@@ -69,14 +69,14 @@ describe Admin::MembersController, :type => :controller do
         allow_any_instance_of(Member).to receive(:save).and_return(false)
         post :create, {:member => { "name" => "invalid value" }}, valid_session
 
-        assigns(:member).should be_a_new(Member)
+        expect(assigns(:member)).to be_a_new(Member)
       end
 
       it "re-renders the 'new' template" do
         allow_any_instance_of(Member).to receive(:save).and_return(false)
         post :create, {:member => { "name" => "invalid value" }}, valid_session
 
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end
@@ -94,14 +94,14 @@ describe Admin::MembersController, :type => :controller do
         member = Member.create! valid_attributes
         put :update, {:id => member.to_param, :member => valid_attributes}, valid_session
 
-        assigns(:member).should eq(member)
+        expect(assigns(:member)).to eq(member)
       end
 
       it "redirects to the member" do
         member = Member.create! valid_attributes
         put :update, {:id => member.to_param, :member => valid_attributes}, valid_session
 
-        response.should redirect_to([:admin, :members])
+        expect(response).to redirect_to([:admin, :members])
       end
     end
 
@@ -111,7 +111,7 @@ describe Admin::MembersController, :type => :controller do
         allow_any_instance_of(Member).to receive(:save).and_return(false)
         put :update, {:id => member.to_param, :member => { "wrong_param" => "invalid value" }}, valid_session
 
-        response.should render_template("edit")
+        expect(response).to render_template("edit")
       end
     end
   end

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -12,7 +12,7 @@ describe Admin::SponsorsController, :type => :controller do
     it "assigns all sponsors as @sponsors" do
       sponsor = Sponsor.create! valid_attributes
       get :index, {}, valid_session
-      assigns(:sponsors).should eq([sponsor])
+      expect(assigns(:sponsors)).to eq([sponsor])
     end
   end
 
@@ -20,14 +20,14 @@ describe Admin::SponsorsController, :type => :controller do
     it "assigns the requested sponsor as @sponsor" do
       sponsor = Sponsor.create! valid_attributes
       get :show, {:id => sponsor.to_param}, valid_session
-      assigns(:sponsor).should eq(sponsor)
+      expect(assigns(:sponsor)).to eq(sponsor)
     end
   end
 
   describe "GET new" do
     it "assigns a new sponsor as @sponsor" do
       get :new, {}, valid_session
-      assigns(:sponsor).should be_a_new(Sponsor)
+      expect(assigns(:sponsor)).to be_a_new(Sponsor)
     end
   end
 
@@ -35,7 +35,7 @@ describe Admin::SponsorsController, :type => :controller do
     it "assigns the requested sponsor as @sponsor" do
       sponsor = Sponsor.create! valid_attributes
       get :edit, {:id => sponsor.to_param}, valid_session
-      assigns(:sponsor).should eq(sponsor)
+      expect(assigns(:sponsor)).to eq(sponsor)
     end
   end
 
@@ -49,13 +49,13 @@ describe Admin::SponsorsController, :type => :controller do
 
       it "assigns a newly created sponsor as @sponsor" do
         post :create, {:sponsor => valid_attributes}, valid_session
-        assigns(:sponsor).should be_a(Sponsor)
-        assigns(:sponsor).should be_persisted
+        expect(assigns(:sponsor)).to be_a(Sponsor)
+        expect(assigns(:sponsor)).to be_persisted
       end
 
       it "redirects to the created sponsor" do
         post :create, {:sponsor => valid_attributes}, valid_session
-        response.should redirect_to([:admin, Sponsor.last])
+        expect(response).to redirect_to([:admin, Sponsor.last])
       end
     end
 
@@ -63,13 +63,13 @@ describe Admin::SponsorsController, :type => :controller do
       it "assigns a newly created but unsaved sponsor as @sponsor" do
         allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         post :create, {:sponsor => { "name" => "invalid value" }}, valid_session
-        assigns(:sponsor).should be_a_new(Sponsor)
+        expect(assigns(:sponsor)).to be_a_new(Sponsor)
       end
 
       it "re-renders the 'new' template" do
         allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         post :create, {:sponsor => { "name" => "invalid value" }}, valid_session
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end
@@ -85,13 +85,13 @@ describe Admin::SponsorsController, :type => :controller do
       it "assigns the requested sponsor as @sponsor" do
         sponsor = Sponsor.create! valid_attributes
         put :update, {:id => sponsor.to_param, :sponsor => valid_attributes}, valid_session
-        assigns(:sponsor).should eq(sponsor)
+        expect(assigns(:sponsor)).to eq(sponsor)
       end
 
       it "redirects to the sponsor" do
         sponsor = Sponsor.create! valid_attributes
         put :update, {:id => sponsor.to_param, :sponsor => valid_attributes}, valid_session
-        response.should redirect_to([:admin, sponsor])
+        expect(response).to redirect_to([:admin, sponsor])
       end
     end
 
@@ -100,14 +100,14 @@ describe Admin::SponsorsController, :type => :controller do
         sponsor = Sponsor.create! valid_attributes
         allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         put :update, {:id => sponsor.to_param, :sponsor => { "name" => "invalid value" }}, valid_session
-        assigns(:sponsor).should eq(sponsor)
+        expect(assigns(:sponsor)).to eq(sponsor)
       end
 
       it "re-renders the 'edit' template" do
         sponsor = Sponsor.create! valid_attributes
         allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         put :update, {:id => sponsor.to_param, :sponsor => { "name" => "invalid value" }}, valid_session
-        response.should render_template("edit")
+        expect(response).to render_template("edit")
       end
     end
   end
@@ -123,7 +123,7 @@ describe Admin::SponsorsController, :type => :controller do
     it "redirects to the sponsors list" do
       sponsor = Sponsor.create! valid_attributes
       delete :destroy, {:id => sponsor.to_param}, valid_session
-      response.should redirect_to(admin_sponsors_path)
+      expect(response).to redirect_to(admin_sponsors_path)
     end
   end
 

--- a/spec/controllers/admin/sponsors_controller_spec.rb
+++ b/spec/controllers/admin/sponsors_controller_spec.rb
@@ -61,13 +61,13 @@ describe Admin::SponsorsController, :type => :controller do
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved sponsor as @sponsor" do
-        Sponsor.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         post :create, {:sponsor => { "name" => "invalid value" }}, valid_session
         assigns(:sponsor).should be_a_new(Sponsor)
       end
 
       it "re-renders the 'new' template" do
-        Sponsor.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         post :create, {:sponsor => { "name" => "invalid value" }}, valid_session
         response.should render_template("new")
       end
@@ -78,7 +78,7 @@ describe Admin::SponsorsController, :type => :controller do
     describe "with valid params" do
       it "updates the requested sponsor" do
         sponsor = Sponsor.create! valid_attributes
-        Sponsor.any_instance.should_receive(:update).with({ "name" => "MyString" })
+        expect_any_instance_of(Sponsor).to receive(:update).with({ "name" => "MyString" })
         put :update, {:id => sponsor.to_param, :sponsor => { "name" => "MyString" }}, valid_session
       end
 
@@ -98,14 +98,14 @@ describe Admin::SponsorsController, :type => :controller do
     describe "with invalid params" do
       it "assigns the sponsor as @sponsor" do
         sponsor = Sponsor.create! valid_attributes
-        Sponsor.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         put :update, {:id => sponsor.to_param, :sponsor => { "name" => "invalid value" }}, valid_session
         assigns(:sponsor).should eq(sponsor)
       end
 
       it "re-renders the 'edit' template" do
         sponsor = Sponsor.create! valid_attributes
-        Sponsor.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Sponsor).to receive(:save).and_return(false)
         put :update, {:id => sponsor.to_param, :sponsor => { "name" => "invalid value" }}, valid_session
         response.should render_template("edit")
       end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -5,7 +5,7 @@ describe ErrorsController, :type => :controller do
   describe "GET 'not_found'" do
     it "returns http not_found" do
       get 'not_found'
-      response.response_code.should == 404
+      expect(response.response_code).to eq(404)
     end
   end
 

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -17,8 +17,8 @@ describe AdminMailer do
 
 
   after(:each) do
-    ActionMailer::Base.deliveries.last.subject.should eq @email_subject
-    ActionMailer::Base.deliveries.last.to.first.to_s.should == "railsgirlslondon@gmail.com"
+    expect(ActionMailer::Base.deliveries.last.subject).to eq @email_subject
+    expect(ActionMailer::Base.deliveries.last.to.first.to_s).to eq("railsgirlslondon@gmail.com")
   end
 
   def html_body

--- a/spec/mailers/registration_mailer_spec.rb
+++ b/spec/mailers/registration_mailer_spec.rb
@@ -7,11 +7,11 @@ describe RegistrationMailer do
     registration = Fabricate(:registration)
 
     RegistrationMailer.application_received(event, registration).deliver_now
-    ActionMailer::Base.deliveries.last.From.to_s.should == "Rails Girls London <railsgirlslondon@gmail.com>"
-    ActionMailer::Base.deliveries.last.To.to_s.should == registration.email
-    ActionMailer::Base.deliveries.last.subject.to_s.should include event.dates
-    ActionMailer::Base.deliveries.last.body.encoded.should include registration.first_name
-    ActionMailer::Base.deliveries.last.body.encoded.should include event.dates
+    expect(ActionMailer::Base.deliveries.last.From.to_s).to eq("Rails Girls London <railsgirlslondon@gmail.com>")
+    expect(ActionMailer::Base.deliveries.last.To.to_s).to eq(registration.email)
+    expect(ActionMailer::Base.deliveries.last.subject.to_s).to include event.dates
+    expect(ActionMailer::Base.deliveries.last.body.encoded).to include registration.first_name
+    expect(ActionMailer::Base.deliveries.last.body.encoded).to include event.dates
   end
 
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -56,7 +56,7 @@ describe Event do
 
       context "no registration deadline" do
         let(:date) { nil }
-        it { should be false }
+        it { is_expected.to be false }
       end
     end
 
@@ -65,17 +65,17 @@ describe Event do
 
       context "deadline in future" do
         let(:date) { 2.days.from_now }
-        it { should be true }
+        it { is_expected.to be true }
       end
 
       context "deadline today" do
         let(:date) { Date.today }
-        it { should be true }
+        it { is_expected.to be true }
       end
 
       context "deadline in the past" do
         let(:date) { Date.yesterday }
-        it { should be false }
+        it { is_expected.to be false }
       end
     end
   end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -6,10 +6,10 @@ describe Invitation do
   let!(:hosting) { Fabricate(:hosting, sponsorable: event) }
   let(:invitation) { Fabricate(:invitation, invitable: event) }
 
-  it { should callback(:generate_token).before(:create) }
-  it { should callback(:send_invitation).after(:create) }
-  it { should callback(:give_away_spot).after(:update) }
-  it { should callback(:send_confirmation).after(:update) }
+  it { is_expected.to callback(:generate_token).before(:create) }
+  it { is_expected.to callback(:send_invitation).after(:create) }
+  it { is_expected.to callback(:give_away_spot).after(:update) }
+  it { is_expected.to callback(:send_confirmation).after(:update) }
 
   context "scopes" do
 
@@ -18,7 +18,7 @@ describe Invitation do
     let!(:waiting_list) { 5.times.map { Fabricate(:waiting_invitation, invitable: event) } }
 
     it "#accepted" do
-      event.invitations.accepted.should eq attending
+      expect(event.invitations.accepted).to eq attending
     end
 
     it "#waiting_list" do
@@ -27,7 +27,7 @@ describe Invitation do
     end
 
     it "#pending_response" do
-      event.invitations.pending_response.should eq no_response.reverse
+      expect(event.invitations.pending_response).to eq no_response.reverse
     end
 
   end
@@ -45,7 +45,7 @@ describe Invitation do
       context "attendance is false" do
         it "processess the waiting list" do
           other_invitation = Fabricate(:invitation, invitable: event, waiting_list: true)
-          invitation.invitable.should_receive(:process_waiting_list)
+          expect(invitation.invitable).to receive(:process_waiting_list)
 
           invitation.update_attribute(:attending, false)
         end
@@ -55,7 +55,7 @@ describe Invitation do
         let(:invitation) { Fabricate(:invitation, invitable: event, waiting_list: true) }
 
         it "sends a confirmation email" do
-          invitation.should_receive(:send_confirmation)
+          expect(invitation).to receive(:send_confirmation)
 
           invitation.update_attributes(attending: true, waiting_list: false)
         end
@@ -65,19 +65,19 @@ describe Invitation do
 
   context "methods" do
     it "#send_invitation" do
-      invitation.invitable.should_receive(:email).with(:invite, invitation.invitee, invitation)
+      expect(invitation.invitable).to receive(:email).with(:invite, invitation.invitee, invitation)
 
       invitation.send_invitation
     end
 
     it "#send_attendance_confirmation" do
-      invitation.invitable.should_receive(:email).with(:confirm_attendance, invitation.invitee, invitation)
+      expect(invitation.invitable).to receive(:email).with(:confirm_attendance, invitation.invitee, invitation)
 
       invitation.send_confirmation
     end
 
     it "#send_reminder" do
-      invitation.invitable.should_receive(:email).with(:invitation_reminder, invitation.invitee, invitation)
+      expect(invitation.invitable).to receive(:email).with(:invitation_reminder, invitation.invitee, invitation)
 
       invitation.send_reminder
     end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -34,7 +34,7 @@ describe Invitation do
 
   context "hooks" do
     it "#after_create" do
-      Invitation.any_instance.should_receive(:send_invitation)
+      expect_any_instance_of(Invitation).to receive(:send_invitation)
 
       Invitation.create! invitee: invitee, invitable: event
     end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -4,7 +4,7 @@ describe Registration do
   let(:registration) { Fabricate(:registration) }
 
   it '#fullname' do
-    registration.fullname.should eq "#{registration.first_name} #{registration.last_name}"
+    expect(registration.fullname).to eq "#{registration.first_name} #{registration.last_name}"
   end
 
   it '#to_s' do
@@ -14,7 +14,7 @@ describe Registration do
      :programming_experience,
      :spoken_languages,
      :preferred_language].each do |information|
-      registration.to_s.should include registration.send information
+      expect(registration.to_s).to include registration.send information
     end
   end
 
@@ -23,14 +23,14 @@ describe Registration do
                                                  selection_state: "accepted",
                                                  attending: true) }
 
-    Registration.accepted.to_a.should eq accepted_registrations
+    expect(Registration.accepted.to_a).to eq accepted_registrations
   end
 
   it "#mark_selection" do
     registration.mark_selection "accepted"
 
 
-    registration.selection_state.should eq "accepted"
+    expect(registration.selection_state).to eq "accepted"
   end
 
   describe "validation contexts" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,4 +68,15 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -1,11 +1,11 @@
 module ControllerHelpers
   def sign_in(user = double('user'))
     if user.nil?
-      request.env['warden'].stub(:authenticate!).
+      allow(request.env['warden']).to receive(:authenticate!).
         and_throw(:warden, {:scope => :user})
-        allow(controller).to receive_messages(:current_user =>  nil)
+      allow(controller).to receive_messages(:current_user =>  nil)
     else
-      request.env['warden'].stub :authenticate! => user
+      allow(request.env['warden']).to receive(:authenticate!).and_return(user)
       allow(controller).to receive_messages(:current_user =>  user)
     end
   end


### PR DESCRIPTION
Bring RSpec syntax up-to-date to stop the deprecation warnings, and put us in a better position for the future.