### PR TITLE
Only list coaches who are attending

### DIFF
--- a/app/models/extentions/coachable.rb
+++ b/app/models/extentions/coachable.rb
@@ -11,7 +11,11 @@ module Extentions
       has_many :coachings, as: :coachable
       has_many :coaches, through: :coachings do
         def who_attended
-          where("coachings.attended" => [Coaching.attendeds[:unknown], Coaching.attendeds[:attended]])
+          where("coachings.attended" => [
+            nil,
+            Coaching.attendeds[:unknown],
+            Coaching.attendeds[:attended]
+          ])
         end
       end
 

--- a/app/models/extentions/coachable.rb
+++ b/app/models/extentions/coachable.rb
@@ -9,7 +9,11 @@ module Extentions
       attr_accessible :coachable
 
       has_many :coachings, as: :coachable
-      has_many :coaches, through: :coachings
+      has_many :coaches, through: :coachings do
+        def who_attended
+          where("coachings.attended" => [Coaching.attendeds[:unknown], Coaching.attendeds[:attended]])
+        end
+      end
 
       has_many :organisers, -> { where :"coachings.organiser" => true }, through: :coachings, source: :coach
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -138,7 +138,7 @@
                   = sponsor.description
 %br
 
-  = render partial: "shared/coaches", locals: { coaches: @event.coaches, title: "Organisers and coaches" }
+  = render partial: "shared/coaches", locals: { coaches: @event.coaches.who_attended, title: "Organisers and coaches" }
 
   - if @event.registrations_open?
     .section.separator.title

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -17,13 +17,14 @@ describe Event do
 
   describe "#coaches.who_attended" do
     let!(:event) { Fabricate(:event) }
+    let!(:coaching_nil) { Fabricate(:event_coaching, coachable_id: event.id) }
     let!(:coaching_unknown) { Fabricate(:event_coaching, coachable_id: event.id, attended: :unknown) }
     let!(:coaching_attended) { Fabricate(:event_coaching, coachable_id: event.id, attended: :attended) }
     let!(:coaching_cancelled) { Fabricate(:event_coaching, coachable_id: event.id, attended: :cancelled) }
     let!(:coaching_no_show) { Fabricate(:event_coaching, coachable_id: event.id, attended: :no_show) }
 
     it "lists only unknown and attending coaches" do
-      expect(event.coaches.who_attended).to eq([coaching_unknown.coach, coaching_attended.coach])
+      expect(event.coaches.who_attended).to eq([coaching_nil.coach, coaching_unknown.coach, coaching_attended.coach])
     end
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -15,6 +15,18 @@ describe Event do
     end
   end
 
+  describe "#coaches.who_attended" do
+    let!(:event) { Fabricate(:event) }
+    let!(:coaching_unknown) { Fabricate(:event_coaching, coachable_id: event.id, attended: :unknown) }
+    let!(:coaching_attended) { Fabricate(:event_coaching, coachable_id: event.id, attended: :attended) }
+    let!(:coaching_cancelled) { Fabricate(:event_coaching, coachable_id: event.id, attended: :cancelled) }
+    let!(:coaching_no_show) { Fabricate(:event_coaching, coachable_id: event.id, attended: :no_show) }
+
+    it "lists only unknown and attending coaches" do
+      expect(event.coaches.who_attended).to eq([coaching_unknown.coach, coaching_attended.coach])
+    end
+  end
+
   describe "registrations" do
     let(:event) { Event.new(registration_deadline: date) }
 


### PR DESCRIPTION
Added `who_attended` method on the coaches association for filtering only those who are unknown or attended.

Closes #239
