### PR TITLE
Special ordering of homepage sponsor logos

### DIFF
--- a/app/comparators/sponsor_comparator.rb
+++ b/app/comparators/sponsor_comparator.rb
@@ -22,7 +22,7 @@ class SponsorComparator
   attr_reader :event
 
   def event_sponsors
-    @event_sponsors ||= event.sponsors
+    @event_sponsors ||= (event.present? ? event.sponsors : [])
   end
 
   def event_sponsor?(sponsor)

--- a/app/comparators/sponsor_comparator.rb
+++ b/app/comparators/sponsor_comparator.rb
@@ -1,0 +1,32 @@
+class SponsorComparator
+
+  def initialize(event)
+    @event = event
+  end
+
+  def sponsors_for_logos
+    Sponsor.all.sort { |a, b|
+      a_is_sponsor = event_sponsor?(a)
+      b_is_sponsor = event_sponsor?(b)
+
+      if a_is_sponsor == b_is_sponsor
+        a.sponsorships.count <=> b.sponsorships.count
+      else
+        a_is_sponsor ? +1 : -1
+      end
+    }.reverse
+  end
+
+  private
+
+  attr_reader :event
+
+  def event_sponsors
+    @event_sponsors ||= event.sponsors
+  end
+
+  def event_sponsor?(sponsor)
+    event_sponsors.include?(sponsor)
+  end
+
+end

--- a/app/comparators/sponsor_comparator.rb
+++ b/app/comparators/sponsor_comparator.rb
@@ -6,11 +6,11 @@ class SponsorComparator
 
   def sponsors_for_logos
     Sponsor.all.sort { |a, b|
-      a_is_sponsor = event_sponsor?(a)
-      b_is_sponsor = event_sponsor?(b)
+      a_is_sponsor = current_event_sponsor?(a)
+      b_is_sponsor = current_event_sponsor?(b)
 
       if a_is_sponsor == b_is_sponsor
-        a.sponsorships.count <=> b.sponsorships.count
+        sort_sponsors_by_relevance(a, b)
       else
         a_is_sponsor ? +1 : -1
       end
@@ -25,8 +25,16 @@ class SponsorComparator
     @event_sponsors ||= (event.present? ? event.sponsors : [])
   end
 
-  def event_sponsor?(sponsor)
+  def current_event_sponsor?(sponsor)
     event_sponsors.include?(sponsor)
+  end
+
+  def sort_sponsors_by_relevance(a, b)
+    if (a.sponsorships.count <=> b.sponsorships.count) == 0
+      a.sponsorships.most_recent.created_at <=> b.sponsorships.most_recent.created_at
+    else
+      a.sponsorships.count <=> b.sponsorships.count
+    end
   end
 
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,6 @@ class HomeController < ApplicationController
   def index
     @next_event = Event.next_event
     @past_events = Event.past
-    @sponsors = Sponsor.all
+    @sponsors = SponsorComparator.new(@next_event).sponsors_for_logos
   end
 end

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -7,6 +7,8 @@ class Sponsorship < ActiveRecord::Base
   validate :host_must_have_address, if: :host?
   validate :host_must_be_unique, if: :host?
 
+  scope :most_recent, -> { order(created_at: :asc).first }
+
   def host_must_have_address
     return if sponsor.has_full_address?
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,7 @@ RailsgirlsLondon::Application.configure do
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
+  config.log_level = :info
 
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load

--- a/spec/comparators/sponsor_comparator_spec.rb
+++ b/spec/comparators/sponsor_comparator_spec.rb
@@ -34,6 +34,21 @@ describe SponsorComparator do
         end
       end
     end
+
+    context "with no upcoming event" do
+      let(:subject) { SponsorComparator.new(nil) }
+
+      let!(:sponsorship1) { Fabricate(:event_sponsorship) }
+      let!(:sponsorship2) { Fabricate(:event_sponsorship) }
+      let!(:sponsorship3) { Fabricate(:event_sponsorship, sponsor: sponsorship2.sponsor, sponsorable_id: event.id) }
+
+      let!(:sponsor1) { sponsorship1.sponsor }
+      let!(:sponsor2) { sponsorship2.sponsor }
+
+      it "returns more frequent sponsors above less frequent" do
+        expect(subject.sponsors_for_logos).to eql([sponsor2, sponsor1])
+      end
+    end
   end
 
 end

--- a/spec/comparators/sponsor_comparator_spec.rb
+++ b/spec/comparators/sponsor_comparator_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe SponsorComparator do
+
+  let(:event) { Fabricate(:event) }
+  let(:subject) { SponsorComparator.new(event) }
+
+  describe "#sponsors_for_logos" do
+    context "with no sponsors" do
+      it "returns an empty array" do
+        expect(subject.sponsors_for_logos).to eql([])
+      end
+    end
+
+    context "with sponsors" do
+      let(:sponsorship1) { Fabricate(:event_sponsorship, sponsorable_id: event.id) }
+      let(:sponsorship2) { Fabricate(:event_sponsorship) }
+
+      let!(:sponsor1) { sponsorship1.sponsor }
+      let!(:sponsor2) { sponsorship2.sponsor }
+
+      it "returns current sponsors highest" do
+        expect(subject.sponsors_for_logos).to eql([sponsor1, sponsor2])
+      end
+
+      context "for the same event" do
+        let!(:sponsorship3) { Fabricate(:event_sponsorship, sponsorable_id: event.id) }
+        let!(:sponsorship4) { Fabricate(:event_sponsorship, sponsor: sponsorship3.sponsor, sponsorable_id: sponsorship2.sponsorable_id) }
+
+        let!(:sponsor3) { sponsorship3.sponsor }
+
+        it "returns more frequent sponsors above less frequent" do
+          expect(subject.sponsors_for_logos).to eql([sponsor3, sponsor1, sponsor2])
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
- Current event sponsors first followed by everyone else
- Within those two groups, sponsors of more events will appear higher

Closes #244 