### PR TITLE
Use the same logo footer for invitation reminder emails

### DIFF
--- a/app/views/event_mailer/invitation_reminder.html.haml
+++ b/app/views/event_mailer/invitation_reminder.html.haml
@@ -22,7 +22,4 @@
     %p.lead{ style: "font-size: 15px; color: #4E5563; margin-top: 25px;" }
       %strong Hope to see you at the workshop!
 
-  .bottom{ style: "width: 100%; padding: 50px 0 0 0px; display: block;" }
-    %strong Sponsors:
-    %br
-    = image_tag attachments["funding-circle.jpg"].url, width: '180px', style: "display: inline-block; padding-right: 10px"
+  = render 'sponsor/email_logos'


### PR DESCRIPTION
This should also fix our failing Travis tests.
